### PR TITLE
BREAKING CHANGE: make 2nd param an object that has 2 properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ try {
 
 [Archetypes are composable, inspectable, and extendable via `extends`.](http://thecodebarbarian.com/casting-mongodb-queries-with-archetype.html)
 
+## Type Properties
+
+Archetype uses nested objects to describe the properties that are allowed in
+an object. A key that starts with `$` identifies an object as a _type description_.
+The following type properties are supported:
+
+* `$type`: the type to cast `value` to
+* `$required`: if falsy, `null` and `undefined` are valid values for this path. If true, `null` and `undefined` are not allowed. Can also handle a function `$required: doc => {}`. If the `$required` function returns falsy, `null` and `undefined` are valid, otherwise they are not.
+* `$default`: use this value instead if this path is `null` or `undefined`. If `$default` is a function `$default: doc => {}`, archetype will use the return value of the function.
+* `$validate`: executes a function that validates `value`. If this function throws, archetype will report an error for this path. Function signature is `$validate: (v, { typeProps, doc }) => {}`
+* `$enum`: lists valid values for this path, modulo `null` and `undefined` if `$required` is falsy.
+
 ## Connect
 
 Follow [archetype on Twitter](https://twitter.com/archetype_js) for updates, including our gists of the week. Here's some older gists of the week:


### PR DESCRIPTION
@jarryd999 

Before: https://gist.github.com/vkarpov15/dcf7c490c69e625764c0dc1453555524

After:

```javascript
// The 2nd param to the `$validate` function is the schema path,
// so `{ $type: 'number', ... }`. Can use that to configure
// validators from your schema path, like writing your own
// min/max validator
const minMax = (v, { typeProps }) => {
  const { $min, $max } = typeProps;
  assert.ok($min == null || v >= $min, `${v} < ${$min}`);
  assert.ok($max == null || v <= $max, `${v} > ${$max}`);
};

const TweetType = new Archetype({
  length: {
    $type: 'number',
    // minMax gets access to `$min` and `$max` below
    $validate: minMax,
    $min: 0,
    $max: 140
  },
  retweets: {
    $type: 'number',
    // minMax behaves differently because different `$min` and `$max`
    $validate: minMax,
    $min: 100
  }
}).compile('TweetType');

// OK
new TweetType({ length: 127, retweets: 100 });

try {
  new TweetType({ length: 151 });
} catch (error) {
  // Error: length: 151 > 140
  console.error(error.message);
}
```