### PR TITLE
fix(import): Remove unused import of index.js in src/unmarshal/index.js

### DIFF
--- a/src/unmarshal/index.js
+++ b/src/unmarshal/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Schema = require('../').Schema;
 const StandardError = require('standard-error');
 const ValidateError = require('./error');
 const applyDefaults = require('../defaults');


### PR DESCRIPTION
:wave: 

Running `madge --circular index.js` gives us:

```
Processed 17 files (755ms) (4 warnings)

✖ Found 1 circular dependency!

1) src/index.js > src/type.js > src/unmarshal/index.js
```

Switching to Node 14.x makes the following warning be raised when starting a script depending directly or indirectly on this dependency:

```
(node:10586) Warning: Accessing non-existent property 'Schema' of module exports inside circular dependency
```

The following import does not appear to be useful and removing it fixes the issue:

```
const Schema = require('../').Schema;
```